### PR TITLE
Fix SessionRepository methods

### DIFF
--- a/internal/repository/session/session.go
+++ b/internal/repository/session/session.go
@@ -2,7 +2,10 @@ package session
 
 import (
 	"context"
+	"errors"
+
 	"github.com/chatbox/whatsapp/internal/domain"
+	"gorm.io/gorm"
 )
 
 func (r *SessionRepository) GetActiveSessions(ctx context.Context) ([]domain.Session, error) {
@@ -19,13 +22,17 @@ func (r *SessionRepository) GetActiveSessions(ctx context.Context) ([]domain.Ses
 }
 
 func (r *SessionRepository) Save(ctx context.Context, model *domain.Session) error {
-	return r.db.WithContext(ctx).Save(&model).Error
+	return r.db.WithContext(ctx).Save(model).Error
 }
 
 func (r *SessionRepository) GetByToken(ctx context.Context, token string) (model *domain.Session, err error) {
-	err = r.db.WithContext(ctx).Where("token = ?", token).Find(model).Error
+	model = &domain.Session{}
+	err = r.db.WithContext(ctx).Where("token = ?", token).First(model).Error
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, gorm.ErrRecordNotFound
+		}
 		return nil, err
 	}
-	return model, err
+	return model, nil
 }


### PR DESCRIPTION
## Summary
- fix incorrect pointer usage in `Save`
- correctly fetch sessions by token and handle not-found case

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/golang.org/toolchain/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684af460258c8329beb8c6d6ad73e0bc