### PR TITLE
Add automigration on DB init

### DIFF
--- a/internal/infrastructure/db.go
+++ b/internal/infrastructure/db.go
@@ -3,6 +3,7 @@ package infrastructure
 import (
 	"fmt"
 	"github.com/chatbox/whatsapp/internal/config"
+	"github.com/chatbox/whatsapp/internal/domain"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -11,6 +12,9 @@ func NewDB(cfg *config.Config) (*gorm.DB, error) {
 	db, err := gorm.Open(postgres.Open(cfg.DBConfig.DatabaseUrl), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to DB: %w", err)
+	}
+	if err := db.AutoMigrate(&domain.Session{}, &domain.Chat{}, &domain.Message{}); err != nil {
+		return nil, fmt.Errorf("failed to migrate DB: %w", err)
 	}
 	return db, nil
 }

--- a/internal/repository/chat/chat_repository.go
+++ b/internal/repository/chat/chat_repository.go
@@ -11,7 +11,6 @@ type GormChatRepository struct {
 }
 
 func NewChatRepository(db *gorm.DB) *GormChatRepository {
-	db.AutoMigrate(&domain.Chat{}, &domain.Message{})
 	return &GormChatRepository{db: db}
 }
 


### PR DESCRIPTION
## Summary
- auto-migrate Session, Chat and Message models when creating DB
- remove redundant auto-migrate from chat repository

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684afdc6dd28832982a869e5074f625b